### PR TITLE
auto detect duallayer discs

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -48,7 +48,7 @@
 #define HW_ARMIRQMASK 	(HW_REG_BASE + 0x03c)
 #define HW_ARMIRQFLAG 	(HW_REG_BASE + 0x038)
 
-#define MAX_WII_OPTIONS 3
+#define MAX_WII_OPTIONS 2
 #define MAX_NGC_OPTIONS 3
 
 // Version info
@@ -108,13 +108,6 @@ enum alignBoundaryOptions
   ALIGN_2,
   ALIGN_512,
   ALIGNB_DELIM
-};
-
-enum dualOptions
-{
-  SINGLE_LAYER=0,
-  DUAL_LAYER,
-  DUAL_DELIM
 };
 
 enum chunkOptions

--- a/source/main.c
+++ b/source/main.c
@@ -69,7 +69,7 @@ static int calcChecksums = 0;
 static int dumpCounter = 0;
 static char gameName[32];
 static char internalName[512];
-static int isDuallayerDisc;
+static int isDuallayerDisc = 0;
 static char mountPath[512];
 static char wpadNeedScan = 0;
 static char padNeedScan = 0;

--- a/source/main.c
+++ b/source/main.c
@@ -56,6 +56,7 @@ static ntfs_md *mounts = NULL;
 const DISC_INTERFACE* sdcard = &__io_wiisd;
 const DISC_INTERFACE* usb = &__io_usbstorage;
 static char rawNTFSMount[512];
+static int isDuallayerDisc;
 #endif
 #ifdef HW_DOL
 #include <sdcard/gcsd.h>
@@ -632,6 +633,19 @@ static int force_disc() {
 	while ((get_buttons_pressed() & PAD_BUTTON_A))
 		;
 	return type;
+}
+
+/* detect if a dual layer disc was inserted based on the gameID */
+int detect_duallayer_disc() {
+    // list of gameIDs from here: https://wiki.dolphin-emu.org/index.php?title=Category:Dual_Layer_Disc_games
+    if (strstr(gameName, "SQI") != NULL || strstr(gameName, "R3O") != NULL || strstr(gameName, "R3M") != NULL ||
+        strstr(gameName, "RXM") != NULL || strstr(gameName, "SR5") != NULL || strstr(gameName, "SAK") != NULL ||
+        strstr(gameName, "S59") != NULL || strstr(gameName, "S5Q") != NULL || strstr(gameName, "RSB") != NULL ||
+        strstr(gameName, "SOU") != NULL || strstr(gameName, "SLS") != NULL || strstr(gameName, "SX4") != NULL ||
+        strstr(gameName, "SZ3") != NULL) {
+        return 1;
+    }
+    return 0;
 }
 
 /* the user must specify the device type */
@@ -1305,6 +1319,10 @@ int main(int argc, char **argv) {
 		if (disc_type == IS_UNK_DISC) {
 			disc_type = force_disc();
 		}
+
+#ifdef HW_RVL
+        isDuallayerDisc = detect_duallayer_disc();
+#endif
 
 		if(reuseSettings == NOT_ASKED || reuseSettings == ANSWER_NO) {
 			if (disc_type == IS_WII_DISC) {

--- a/source/main.c
+++ b/source/main.c
@@ -56,7 +56,6 @@ static ntfs_md *mounts = NULL;
 const DISC_INTERFACE* sdcard = &__io_wiisd;
 const DISC_INTERFACE* usb = &__io_usbstorage;
 static char rawNTFSMount[512];
-static int isDuallayerDisc;
 #endif
 #ifdef HW_DOL
 #include <sdcard/gcsd.h>
@@ -70,6 +69,7 @@ static int calcChecksums = 0;
 static int dumpCounter = 0;
 static char gameName[32];
 static char internalName[512];
+static int isDuallayerDisc;
 static char mountPath[512];
 static char wpadNeedScan = 0;
 static char padNeedScan = 0;
@@ -737,15 +737,6 @@ char *getAlignmentBoundaryOption() {
 	return 0;
 }
 
-char *getDualLayerOption() {
-	int opt = options_map[WII_DUAL_LAYER];
-	if (opt == SINGLE_LAYER)
-		return "No";
-	else if (opt == DUAL_LAYER)
-		return "Yes";
-	return 0;
-}
-
 char *getNewFileOption() {
 	int opt = options_map[WII_NEWFILE];
 	if (opt == ASK_USER)
@@ -770,8 +761,6 @@ char *getChunkSizeOption() {
 
 int getMaxPos(int option_pos) {
 	switch (option_pos) {
-	case WII_DUAL_LAYER:
-		return DUAL_DELIM;
 	case WII_CHUNK_SIZE:
 		return CHUNK_DELIM;
 	case NGC_ALIGN_BOUNDARY:
@@ -822,8 +811,8 @@ static void get_settings(int disc_type) {
 		}
 		// Wii Settings
 		else if(disc_type == IS_WII_DISC) {
-			WriteFont(80, 160+(32*1), "Dual Layer");
-			DrawSelectableButton(vmode->fbWidth-220, 160+(32*1), -1, 160+(32*1)+30, getDualLayerOption(), (!currentSettingPos) ? B_SELECTED:B_NOSELECT, -1);
+			// WriteFont(80, 160+(32*1), "Dual Layer");
+			// DrawSelectableButton(vmode->fbWidth-220, 160+(32*1), -1, 160+(32*1)+30, getDualLayerOption(), (!currentSettingPos) ? B_SELECTED:B_NOSELECT, -1);
 			WriteFont(80, 160+(32*2), "Chunk Size");
 			DrawSelectableButton(vmode->fbWidth-220, 160+(32*2), -1, 160+(32*2)+30, getChunkSizeOption(), (currentSettingPos==1) ? B_SELECTED:B_NOSELECT, -1);
 			WriteFont(80, 160+(32*3), "New device per chunk");
@@ -1015,8 +1004,7 @@ int dump_game(int disc_type, int type, int fs) {
 
 	u32 startLBA = 0;
 	u32 endLBA = (disc_type == IS_NGC_DISC || disc_type == IS_DATEL_DISC) ? NGC_DISC_SIZE
-			: (options_map[WII_DUAL_LAYER] == DUAL_LAYER ? WII_D9_SIZE
-					: WII_D5_SIZE);
+			: (isDuallayerDisc ? WII_D9_SIZE : WII_D5_SIZE);
 
 	// Work out the chunk size
 	u32 chunk_size_wii = options_map[WII_CHUNK_SIZE];

--- a/source/main.c
+++ b/source/main.c
@@ -811,12 +811,10 @@ static void get_settings(int disc_type) {
 		}
 		// Wii Settings
 		else if(disc_type == IS_WII_DISC) {
-			// WriteFont(80, 160+(32*1), "Dual Layer");
-			// DrawSelectableButton(vmode->fbWidth-220, 160+(32*1), -1, 160+(32*1)+30, getDualLayerOption(), (!currentSettingPos) ? B_SELECTED:B_NOSELECT, -1);
-			WriteFont(80, 160+(32*2), "Chunk Size");
-			DrawSelectableButton(vmode->fbWidth-220, 160+(32*2), -1, 160+(32*2)+30, getChunkSizeOption(), (currentSettingPos==1) ? B_SELECTED:B_NOSELECT, -1);
-			WriteFont(80, 160+(32*3), "New device per chunk");
-			DrawSelectableButton(vmode->fbWidth-220, 160+(32*3), -1, 160+(32*3)+30, getNewFileOption(), (currentSettingPos==2) ? B_SELECTED:B_NOSELECT, -1);
+			WriteFont(80, 160+(32*1), "Chunk Size");
+			DrawSelectableButton(vmode->fbWidth-220, 160+(32*1), -1, 160+(32*1)+30, getChunkSizeOption(), (!currentSettingPos) ? B_SELECTED:B_NOSELECT, -1);
+			WriteFont(80, 160+(32*2), "New device per chunk");
+			DrawSelectableButton(vmode->fbWidth-220, 160+(32*2), -1, 160+(32*2)+30, getNewFileOption(), (currentSettingPos==1) ? B_SELECTED:B_NOSELECT, -1);
 		}
 		WriteCentre(370,"Press  A  to continue");
 		DrawAButton(265,360);
@@ -825,10 +823,10 @@ static void get_settings(int disc_type) {
 		while (!(get_buttons_pressed() & (PAD_BUTTON_RIGHT | PAD_BUTTON_LEFT | PAD_BUTTON_A | PAD_BUTTON_UP | PAD_BUTTON_DOWN)));
 		u32 btns = get_buttons_pressed();
 		if(btns & PAD_BUTTON_RIGHT) {
-			toggleOption(currentSettingPos+((disc_type == IS_WII_DISC)?MAX_NGC_OPTIONS:0), 1);
+			toggleOption(currentSettingPos+((disc_type == IS_WII_DISC)?MAX_NGC_OPTIONS + 1:0), 1);
 		}
 		if(btns & PAD_BUTTON_LEFT) {
-			toggleOption(currentSettingPos+((disc_type == IS_WII_DISC)?MAX_NGC_OPTIONS:0), -1);
+			toggleOption(currentSettingPos+((disc_type == IS_WII_DISC)?MAX_NGC_OPTIONS + 1:0), -1);
 		}
 		if(btns & PAD_BUTTON_UP) {
 			currentSettingPos = (currentSettingPos>0) ? (currentSettingPos-1):maxSettingPos;


### PR DESCRIPTION
Detect Wii duallayer discs automatically based on gameIDs.

fixes #37 
fixes #67 