### PR TITLE
automatically detect dual-layer discs by attempting to read from the second layer

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -112,7 +112,8 @@ enum alignBoundaryOptions
 
 enum dualOptions
 {
-  SINGLE_LAYER=0,
+  AUTO_DETECT=0,
+  SINGLE_LAYER,
   DUAL_LAYER,
   DUAL_DELIM
 };


### PR DESCRIPTION
This implements the detection of dual-layer discs more elegantly.

I tested it with a lot of single-layer discs and my only dual-layer disc game SSBB. 
It does work, although additional tests with other dual-layer disc games would not hurt.

closes #37 
fixes #67


(the 4 older commits are from my first PR which I improved upon)