### PR TITLE
add build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ If you have any questions about CleanRip?, please make a thread over at http://w
 * USB or SD storage device (>1.35GB free space)
 * HBC 1.0.8 or greater installed 
 
+# Build
+
+1. Install DevkitPro. You can download and install it from the official website: https://devkitpro.org/wiki/Getting_Started
+
+2. Install libogc2 library. libogc2 is a library for Wii and GameCube homebrew development: https://github.com/extremscorner/libogc2
+
+3. Build the project: Run `make` in the root directory of the project.
+
 # Device Compatibility
 Please note that the Wii can be picky about particular USB drives/storage devices. It's recommended to use a Y cable for hard drives that fail to power up from one USB port alone. If USB flash storage doesn't want to work, try a different brand/size. SD cards on GameCube will potentially have similar issues, it's best to have a few different brands/sizes/types at your disposal.
 


### PR DESCRIPTION
Since libogc2 is used, an additional step is needed when building cleanrip. Took me a second to figure out that libogc2 is a new required library. Might help others to mention it in the readme.